### PR TITLE
Fix lsd components dir

### DIFF
--- a/notionExportToDocusaurus.ts
+++ b/notionExportToDocusaurus.ts
@@ -168,17 +168,17 @@ const mapNotionIdToDocusaurusPage = (notionId: string): string | undefined => {
       return '/philosophy/index.md'
     }
 
-    if (notionId === 'dff0a02ce0d8431d8841e97a975844bb') {
-      return 'resources-and-tools/lsd/index.md'
-    }
+    // if (notionId === 'dff0a02ce0d8431d8841e97a975844bb') {
+    //   return 'resources-and-tools/lsd/index.md'
+    // }
 
     // if (notionId === '31ea305ac88342ebbc505ea93e3bca3a') {
     //   return 'resources-and-tools/lsd/design-tokens.md'
     // }
 
-    if (notionId === 'e5522cb5bfc94082adac41f1ab17a673') {
-      return 'resources-and-tools/gallery.md'
-    }
+    // if (notionId === 'e5522cb5bfc94082adac41f1ab17a673') {
+    //   return 'resources-and-tools/gallery.md'
+    // }
 
     if (notionId === '6c4c002d6ead446cb1f58cbb34a7be4c') {
       return 'visual-language/index.md'

--- a/scripts/download-storybook-data.ts
+++ b/scripts/download-storybook-data.ts
@@ -25,7 +25,7 @@ const EXCLUDE_COMPONENTS = [
 
 const STORYBOOK_URL = process.env.STORYBOOK_URL
 const DOCS_DIR = path.join(DATA_DIR, '../docs')
-const LSD_DOCS_DIR = path.join(DOCS_DIR, './resources-and-tools/lsd')
+const LSD_DOCS_DIR = path.join(DOCS_DIR, './lsd')
 const COMPONENTS_DIR = path.join(LSD_DOCS_DIR, './components')
 const DESIGN_TOKENS_DIR = path.join(LSD_DOCS_DIR, './design-tokens')
 


### PR DESCRIPTION
The resources-and-tools directory was removed. However, there was still code creating LSD UI components on that folder. This PR updates this LSD UI components dir to the correct one.