### PR TITLE
New image galleries

### DIFF
--- a/docs/gallery.mdx
+++ b/docs/gallery.mdx
@@ -39,10 +39,4 @@ export const galleryImages = [
     { src: '/28.png'},
 ]
 
-<ImageGrid md={{cols: 2, gap: "16px"}} xs={{cols: 2, gap: "16px"}}>
-    {galleryImages.map((img, index) => (
-        <Grid.Item key={index}>
-            <img src={img.src} />
-        </Grid.Item>
-    ))}
-</ImageGrid>
+<ImageGrid mode="masonry" firstColumnSize={11} imageArray={galleryImages} />

--- a/docs/visual-language/grid-and-layout/non-web-environment.mdx
+++ b/docs/visual-language/grid-and-layout/non-web-environment.mdx
@@ -18,44 +18,16 @@ The typestack for these grids is also based in multiples of 20px, line height ad
 
 2 column 20px and 4 column 20px
 
-<ImageGrid md={{cols: 2, gap: "16px"}}>
-        <Grid.Item>
-            <img src="/Clip_path_group.png" />
-        </Grid.Item>
-        <Grid.Item>
-            <img src="/Logos-Example-2.png" />
-        </Grid.Item>
-</ImageGrid>
+<ImageGrid md={{cols: 2, gap: "16px"}} imageArray={[{src: "/Clip_path_group.png"}, {src: "/Logos-Example-2.png" }]} />
 
 ### Hashing It Out
 
 3 column 20px and 2 column 20px
 
-<ImageGrid md={{cols: 2, gap: "16px"}}>
-        <Grid.Item title="">
-            <img src="/HIO-Examples-1.png" />
-        </Grid.Item>
-        <Grid.Item title="">
-            <img src="/HIO-Examples-2.png" />
-        </Grid.Item>
-</ImageGrid>
-
+<ImageGrid md={{cols: 2, gap: "16px"}} imageArray={[{src: "/HIO-Examples-1.png"}, {src: "/HIO-Examples-2.png"}]} />
 
 ### Generic Twitter
 
 This is a simpler grid based on 96px, used for X. Type sizes are also based on divisions of the 96px unit.
 
-<ImageGrid md={{cols: 2, gap: "16px"}}>
-        <Grid.Item>
-            <img src="/image_5.png" />
-        </Grid.Item>
-        <Grid.Item>
-            <img src="/image_6.png" />
-        </Grid.Item>
-        <Grid.Item>
-            <img src="/image_7.png" />
-        </Grid.Item>
-        <Grid.Item>
-            <img src="/image_8.png" />
-        </Grid.Item>
-</ImageGrid>
+<ImageGrid md={{cols: 2, gap: "16px"}} imageArray={[{src: "/image_5.png"}, {src: "/image_6.png"}, {src: "/image_7.png"}, {src: "/image_8.png"}]} />

--- a/docs/visual-language/grid-and-layout/web-environment.mdx
+++ b/docs/visual-language/grid-and-layout/web-environment.mdx
@@ -39,39 +39,12 @@ Gutter size - 16px.
 
 ### Desktop
 
-<ImageGrid md={{cols: 2, gap: "16px"}}>
-        <Grid.Item>
-            <img src="/Untitled-1.png" />
-        </Grid.Item>
-        <Grid.Item>
-            <img src="/Untitled-2.png" />
-        </Grid.Item>
-        <Grid.Item>
-            <img src="/Untitled-3.png" />
-        </Grid.Item>
-        <Grid.Item>
-            <img src="/Untitled-4.png" />
-        </Grid.Item>
-</ImageGrid>
+<ImageGrid md={{cols: 2, gap: "16px"}} imageArray={[{src: "/Untitled-1.png"}, {src: "/Untitled-2.png"}, {src: "/Untitled-3.png"}, {src: "/Untitled-4.png"}]} />
 
 ### Tablet
 
-<ImageGrid md={{cols: 2, gap: "16px"}}>
-        <Grid.Item>
-            <img src="/Untitled-5.png" />
-        </Grid.Item>
-        <Grid.Item>
-            <img src="/Untitled-6.png" />
-        </Grid.Item>
-</ImageGrid>
+<ImageGrid md={{cols: 2, gap: "16px"}} imageArray={[{src: "/Untitled-5.png"}, {src: "/Untitled-6.png"}]} />
 
 ### Mobile
 
-<ImageGrid md={{cols: 2, gap: "16px"}}>
-        <Grid.Item>
-            <img src="/Untitled-7.png" />
-        </Grid.Item>
-        <Grid.Item>
-            <img src="/Untitled-8.png" />
-        </Grid.Item>
-</ImageGrid>
+<ImageGrid md={{cols: 2, gap: "16px"}} imageArray={[{src: "/Untitled-7.png"}, {src: "/Untitled-8.png"}]} />

--- a/docs/visual-language/illustration.mdx
+++ b/docs/visual-language/illustration.mdx
@@ -91,13 +91,7 @@ Nimbus - Aphrodite with halo, lightness, symbol of love, attraction
 
 Waku - Prometheus, delivering transformative technology
 
-<ImageGrid xs={{cols: 2, gap: "16px"}} md={{cols: 4, gap: "16px"}}>
-    {protocolPromotion.map((img, index) => (
-        <Grid.Item key={index}>
-            <img src={img.src} />
-        </Grid.Item>
-    ))}
-</ImageGrid>
+<ImageGrid mode="square-thumbnails" xs={{cols: 2, gap: "16px"}} md={{cols: 4, gap: "16px"}} imageArray={protocolPromotion} />
 
 ## Conceptual
 
@@ -105,13 +99,7 @@ The selected illustration style is detailed, and symmetrical to suggest the subl
 
 Need to come up with a plan/process for creating/buying/commissioning/using this type of illustration. Could be applicable to Network State Press articles and social promo stuff.
 
-<ImageGrid xs={{cols: 2, gap: "16px"}} md={{cols: 4, gap: "16px"}}>
-    {conceptualImages.map((img, index) => (
-        <Grid.Item key={index}>
-            <img src={img.src} />
-        </Grid.Item>
-    ))}
-</ImageGrid>
+<ImageGrid mode="square-thumbnails" xs={{cols: 2, gap: "16px"}} md={{cols: 4, gap: "16px"}} imageArray={conceptualImages} />
 
 ## Abstract
 
@@ -119,10 +107,4 @@ Texture can be preferable giving a layering or aging effect to the work suggesti
 
 HIO uses these abstracts for the Flash Hash episode covers.
 
-<ImageGrid xs={{cols: 4, gap: "16px"}} md={{cols: 7, gap: "16px"}}>
-    {abstractImages.map((img, index) => (
-        <Grid.Item key={index}>
-            <img src={img.src} />
-        </Grid.Item>
-    ))}
-</ImageGrid>
+<ImageGrid mode="square-thumbnails" xs={{cols: 4, gap: "16px"}} md={{cols: 7, gap: "16px"}} imageArray={abstractImages} />

--- a/docs/visual-language/photography.mdx
+++ b/docs/visual-language/photography.mdx
@@ -66,34 +66,16 @@ We have a unique photography style for each of the following categories; Portrai
 
 This style, primarily used for podcast promotion, incorporates black-and-white visuals with dramatic lighting when feasible. It typically frames subjects with a good amount of head and shoulders. Try to ensure guest consent when possible.
 
-<ImageGrid xs={{cols: 2, gap: "16px"}} md={{cols: 4, gap: "16px"}}>
-    {portraits.map((img, index) => (
-        <Grid.Item key={index}>
-            <img src={img.src} />
-        </Grid.Item>
-    ))}
-</ImageGrid>
+<ImageGrid mode="square-thumbnails" xs={{cols: 2, gap: "16px"}} md={{cols: 4, gap: "16px"}} imageArray={portraits} />
 
 ## Activism
 
 This style is predominantly employed for Network State Press articles and presentations, featuring a black-and-white color scheme. It integrates a journalistic approach with both stock photography and real-life imagery from protests and demonstrations. While a preference is given to free resources, licensed content can also be considered.
 
-<ImageGrid xs={{cols: 2, gap: "16px"}} md={{cols: 4, gap: "16px"}}>
-    {activismImages.map((img, index) => (
-        <Grid.Item key={index}>
-            <img src={img.src} />
-        </Grid.Item>
-    ))}
-</ImageGrid>
+<ImageGrid mode="square-thumbnails" xs={{cols: 2, gap: "16px"}} md={{cols: 4, gap: "16px"}} imageArray={activismImages} />
 
 ## Conceptual
 
 This style is primarily utilized for Network State Press articles and presentations, encompassing a journalistic approach along with the inclusion of stock photography. It is designed to align with fundamental Logos concepts, such as human rights, privacy, and civil liberties. While free resources are preferred, the use of licensed materials can be explored.
 
-<ImageGrid xs={{cols: 2, gap: "16px"}} md={{cols: 4, gap: "16px"}}>
-    {conceptualImages.map((img, index) => (
-        <Grid.Item key={index}>
-            <img src={img.src} />
-        </Grid.Item>
-    ))}
-</ImageGrid>
+<ImageGrid mode="square-thumbnails" xs={{cols: 2, gap: "16px"}} md={{cols: 4, gap: "16px"}} imageArray={conceptualImages} />

--- a/notionExportToDocusaurus.ts
+++ b/notionExportToDocusaurus.ts
@@ -168,18 +168,6 @@ const mapNotionIdToDocusaurusPage = (notionId: string): string | undefined => {
       return '/philosophy/index.md'
     }
 
-    if (notionId === 'dff0a02ce0d8431d8841e97a975844bb') {
-      return 'resources-and-tools/lsd/index.md'
-    }
-
-    // if (notionId === '31ea305ac88342ebbc505ea93e3bca3a') {
-    //   return 'resources-and-tools/lsd/design-tokens.md'
-    // }
-
-    if (notionId === 'e5522cb5bfc94082adac41f1ab17a673') {
-      return 'resources-and-tools/gallery.md'
-    }
-
     if (notionId === '6c4c002d6ead446cb1f58cbb34a7be4c') {
       return 'visual-language/index.md'
     }

--- a/scripts/download-storybook-data.ts
+++ b/scripts/download-storybook-data.ts
@@ -25,7 +25,7 @@ const EXCLUDE_COMPONENTS = [
 
 const STORYBOOK_URL = process.env.STORYBOOK_URL
 const DOCS_DIR = path.join(DATA_DIR, '../docs')
-const LSD_DOCS_DIR = path.join(DOCS_DIR, './resources-and-tools/lsd')
+const LSD_DOCS_DIR = path.join(DOCS_DIR, './lsd')
 const COMPONENTS_DIR = path.join(LSD_DOCS_DIR, './components')
 const DESIGN_TOKENS_DIR = path.join(LSD_DOCS_DIR, './design-tokens')
 

--- a/src/components/mdx/ImageGrid/ImageGrid.module.scss
+++ b/src/components/mdx/ImageGrid/ImageGrid.module.scss
@@ -42,18 +42,16 @@
   z-index: 1000;
 }
 
-.expandedImageContainer {
+.expandedImage {
+  position: fixed;
+
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+
   height: 90vh;
   width: 90vw;
-  overflow: hidden;
 
-  // The following padding top adds a little bit of room for the close button.
-  padding-top: 20px;
-}
-
-.expandedImage {
-  height: 100%;
-  width: 100%;
   display: block;
   object-fit: contain;
 }
@@ -63,7 +61,11 @@
   top: 18px;
   right: 16px;
 
+  background-color: rgb(var(--lsd-theme-secondary)) !important;
+
   cursor: pointer;
+
+  z-index: 1001;
 }
 
 // Single column image galleries on mobile don't have spacing between them.

--- a/src/components/mdx/ImageGrid/ImageGrid.module.scss
+++ b/src/components/mdx/ImageGrid/ImageGrid.module.scss
@@ -1,19 +1,75 @@
 @use "@acid-info/logos-docusaurus-theme/lib/client/css/utils";
 
-.imageGrid > div > div {
-  max-height: 300px;
+.thumbnailImageContainer {
   display: flex;
   justify-content: center;
   align-items: center;
+
+  overflow: hidden;
+  height: 100%;
 }
 
-.imageGrid img {
+.thumbnailImage {
+  min-height: 100%;
+  min-width: 100%;
+  max-height: none;
+  object-fit: cover;
+
   cursor: pointer;
-  max-height: 300px;
 }
 
+.masonry .thumbnailImageContainer {
+  flex-direction: column;
+  margin-bottom: 16px;
+  height: auto; // overrides the height: 100% from the default thumbnailImageContainer
+}
+
+.squareThumbnails .thumbnailImageContainer {
+  aspect-ratio: 1 / 1;
+}
+
+// Overlay and expanded image styles.
+.overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgb(var(--lsd-theme-secondary));
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+}
+
+.expandedImageContainer {
+  height: 90vh;
+  width: 90vw;
+  overflow: hidden;
+
+  // The following padding top adds a little bit of room for the close button.
+  padding-top: 20px;
+}
+
+.expandedImage {
+  height: 100%;
+  width: 100%;
+  display: block;
+  object-fit: contain;
+}
+
+.closeButton {
+  position: fixed;
+  top: 18px;
+  right: 16px;
+
+  cursor: pointer;
+}
+
+// Single column image galleries on mobile don't have spacing between them.
+// The following padding bottom fixes that.
 @include utils.responsive('md', 'down') {
-  .imageGrid > div > div {
-    margin-bottom: 16px;
+  .thumbnailImageContainer {
+    padding-bottom: 16px;
   }
 }

--- a/src/components/mdx/ImageGrid/ImageGrid.module.scss
+++ b/src/components/mdx/ImageGrid/ImageGrid.module.scss
@@ -49,8 +49,8 @@
   left: 50%;
   transform: translate(-50%, -50%);
 
-  height: 90vh;
-  width: 90vw;
+  max-height: 90vh;
+  max-width: 90vw;
 
   display: block;
   object-fit: contain;

--- a/src/components/mdx/ImageGrid/ImageGrid.tsx
+++ b/src/components/mdx/ImageGrid/ImageGrid.tsx
@@ -1,36 +1,143 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import {
   Grid,
   GridProps,
 } from '@acid-info/logos-docusaurus-theme/lib/client/components/mdx'
 import styles from './ImageGrid.module.scss'
+import clsx from 'clsx'
+import { IconButton, CloseIcon } from '@acid-info/lsd-react'
 
-export type ImageGridProps = GridProps & {
-  children: React.ReactNode
+type ImageType = {
+  src: string
+  alt?: string
 }
 
-export const ImageGrid: React.FC<ImageGridProps> = ({ children, ...props }) => {
-  const handleImageClick = event => {
-    // The following code clicks on the lightbox expand button when an image is clicked.
-    if (event.target.tagName === 'IMG') {
-      const siblings = Array.from(event.target.parentElement.children)
+type MasonryModeProps = {
+  setSelectedImage: (image: ImageType | null) => void
+  firstColumnSize: number
+  imageArray: ImageType[]
+}
 
-      siblings.forEach(sibling => {
-        if ((sibling as any).tagName === 'BUTTON') {
-          ;(sibling as any).click() // programmatically click the lightbox expand button.
-        }
-      })
-    }
-  }
+// Masonry mode only has 2 columns with 1 item each.
+const MasonryMode: React.FC<MasonryModeProps> = ({
+  setSelectedImage,
+  firstColumnSize,
+  imageArray,
+}) => {
+  const firstColumnImages = imageArray.slice(0, firstColumnSize)
+  const secondColumnImages = imageArray.slice(firstColumnSize)
 
   return (
-    <Grid
-      md={{ cols: 3, gap: '12px' }}
-      className={styles.imageGrid}
-      onClick={handleImageClick}
-      {...props}
-    >
-      {children}
-    </Grid>
+    <>
+      <Grid.Item>
+        {firstColumnImages.map((image, index) => (
+          <div key={index} className={styles.thumbnailImageContainer}>
+            <img
+              key={index}
+              src={image.src}
+              alt={image.alt || ''}
+              onClick={() => setSelectedImage(image)}
+              className={styles.thumbnailImage}
+            />
+          </div>
+        ))}
+      </Grid.Item>
+      <Grid.Item>
+        {secondColumnImages.map((image, index) => (
+          <div key={index} className={styles.thumbnailImageContainer}>
+            <img
+              key={index}
+              src={image.src}
+              alt={image.alt || ''}
+              onClick={() => setSelectedImage(image)}
+              className={styles.thumbnailImage}
+            />
+          </div>
+        ))}
+      </Grid.Item>
+    </>
+  )
+}
+
+export type ImageGridProps = GridProps & {
+  imageArray: ImageType[]
+  mode?: 'masonry' | 'regular' | 'square-thumbnails'
+  firstColumnSize?: number
+}
+
+export const ImageGrid: React.FC<ImageGridProps> = ({
+  mode = 'regular',
+  imageArray,
+  firstColumnSize = 0, // default value
+  ...props
+}) => {
+  const [selectedImage, setSelectedImage] = useState<null | ImageType>(null)
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setSelectedImage(null)
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown)
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown)
+    }
+  }, [])
+
+  return (
+    <>
+      <Grid
+        md={{ cols: mode === 'masonry' ? 2 : 3, gap: '16px' }}
+        xs={{ cols: 2, gap: '16px' }}
+        className={clsx(
+          styles.imageGrid,
+          mode === 'masonry' && styles.masonry,
+          mode === 'regular' && styles.regular,
+          mode === 'square-thumbnails' && styles.squareThumbnails,
+        )}
+        {...props}
+      >
+        {mode === 'masonry' ? (
+          <MasonryMode
+            setSelectedImage={setSelectedImage}
+            firstColumnSize={firstColumnSize}
+            imageArray={imageArray}
+          />
+        ) : (
+          imageArray.map((image, index) => (
+            <Grid.Item key={index} className={styles.thumbnailImageContainer}>
+              <img
+                src={image.src}
+                alt={image.alt || ''}
+                onClick={() => setSelectedImage(image)}
+                className={styles.thumbnailImage}
+              />
+            </Grid.Item>
+          ))
+        )}
+      </Grid>
+
+      {selectedImage && (
+        <div className={styles.overlay}>
+          <div className={styles.expandedImageContainer}>
+            <IconButton
+              size="small"
+              onClick={() => setSelectedImage(null)}
+              className={styles.closeButton}
+            >
+              <CloseIcon color="primary" />
+            </IconButton>
+            <img
+              src={selectedImage.src}
+              alt={selectedImage.alt || ''}
+              className={styles.expandedImage}
+            />
+          </div>
+        </div>
+      )}
+    </>
   )
 }

--- a/src/components/mdx/ImageGrid/ImageGrid.tsx
+++ b/src/components/mdx/ImageGrid/ImageGrid.tsx
@@ -108,12 +108,23 @@ export const ImageGrid: React.FC<ImageGridProps> = ({
           />
         ) : (
           imageArray.map((image, index) => (
-            <Grid.Item key={index} className={styles.thumbnailImageContainer}>
+            <Grid.Item
+              key={index}
+              className={
+                selectedImage?.src === image.src
+                  ? styles.overlay
+                  : styles.thumbnailImageContainer
+              }
+            >
               <img
                 src={image.src}
                 alt={image.alt || ''}
                 onClick={() => setSelectedImage(image)}
-                className={styles.thumbnailImage}
+                className={
+                  selectedImage?.src === image.src
+                    ? styles.expandedImage
+                    : styles.thumbnailImage
+                }
               />
             </Grid.Item>
           ))
@@ -121,22 +132,13 @@ export const ImageGrid: React.FC<ImageGridProps> = ({
       </Grid>
 
       {selectedImage && (
-        <div className={styles.overlay}>
-          <div className={styles.expandedImageContainer}>
-            <IconButton
-              size="small"
-              onClick={() => setSelectedImage(null)}
-              className={styles.closeButton}
-            >
-              <CloseIcon color="primary" />
-            </IconButton>
-            <img
-              src={selectedImage.src}
-              alt={selectedImage.alt || ''}
-              className={styles.expandedImage}
-            />
-          </div>
-        </div>
+        <IconButton
+          size="small"
+          onClick={() => setSelectedImage(null)}
+          className={styles.closeButton}
+        >
+          <CloseIcon color="primary" />
+        </IconButton>
       )}
     </>
   )

--- a/src/components/mdx/ImageGrid/ImageGrid.tsx
+++ b/src/components/mdx/ImageGrid/ImageGrid.tsx
@@ -16,6 +16,7 @@ type MasonryModeProps = {
   setSelectedImage: (image: ImageType | null) => void
   firstColumnSize: number
   imageArray: ImageType[]
+  selectedImage: ImageType | null
 }
 
 // Masonry mode only has 2 columns with 1 item each.
@@ -23,6 +24,7 @@ const MasonryMode: React.FC<MasonryModeProps> = ({
   setSelectedImage,
   firstColumnSize,
   imageArray,
+  selectedImage,
 }) => {
   const firstColumnImages = imageArray.slice(0, firstColumnSize)
   const secondColumnImages = imageArray.slice(firstColumnSize)
@@ -31,26 +33,48 @@ const MasonryMode: React.FC<MasonryModeProps> = ({
     <>
       <Grid.Item>
         {firstColumnImages.map((image, index) => (
-          <div key={index} className={styles.thumbnailImageContainer}>
+          <div
+            key={index}
+            className={
+              selectedImage?.src === image.src
+                ? styles.overlay
+                : styles.thumbnailImageContainer
+            }
+          >
             <img
               key={index}
               src={image.src}
               alt={image.alt || ''}
               onClick={() => setSelectedImage(image)}
-              className={styles.thumbnailImage}
+              className={
+                selectedImage?.src === image.src
+                  ? styles.expandedImage
+                  : styles.thumbnailImage
+              }
             />
           </div>
         ))}
       </Grid.Item>
       <Grid.Item>
         {secondColumnImages.map((image, index) => (
-          <div key={index} className={styles.thumbnailImageContainer}>
+          <div
+            key={index}
+            className={
+              selectedImage?.src === image.src
+                ? styles.overlay
+                : styles.thumbnailImageContainer
+            }
+          >
             <img
               key={index}
               src={image.src}
               alt={image.alt || ''}
               onClick={() => setSelectedImage(image)}
-              className={styles.thumbnailImage}
+              className={
+                selectedImage?.src === image.src
+                  ? styles.expandedImage
+                  : styles.thumbnailImage
+              }
             />
           </div>
         ))}
@@ -105,6 +129,7 @@ export const ImageGrid: React.FC<ImageGridProps> = ({
             setSelectedImage={setSelectedImage}
             firstColumnSize={firstColumnSize}
             imageArray={imageArray}
+            selectedImage={selectedImage}
           />
         ) : (
           imageArray.map((image, index) => (


### PR DESCRIPTION
This is part of the design review fixes for the brand guidelines page - [Figma link](https://www.figma.com/file/SaEMNg8YI0IFU1CVXFaRwE/Brand-Guidelines-UI?node-id=21%3A4624&mode=dev)

This PR introduces 3 types of image galleries: square thumbnails, masonry, and regular

Note: this PR also removes the previous lightbox functionality from the image galleries. New image expansion logic was implemented. This was done for 2 reasons: 1st because the lightbox containers and logic were interfering with certain parts of the code / CSS, making it harder to implement the different types of image galleries. 2nd reason was to give more control over how the image gallery works - now the expansion logic is 100% controlled by the ImageGallery component, and it is easier to modify / debug / understand.

### 1. Square thumbnails - used in the Illustration and Photography pages

![Screenshot from 2023-11-02 20-00-01](https://github.com/acid-info/logos-brand-guidelines/assets/9993816/baafe227-d748-4365-8d83-a17994acb4b8)


### 2. Masonry - used in the main gallery

![Screenshot from 2023-11-02 19-59-31](https://github.com/acid-info/logos-brand-guidelines/assets/9993816/da9d995d-5259-4a39-8dbb-58107f9e1b97)

### 3. Regular thumbnails - used in the Visual Language -> Grid Layout -> Web Environment (and Non web environment as well) pages

![Screenshot from 2023-11-02 20-01-20](https://github.com/acid-info/logos-brand-guidelines/assets/9993816/26d5abf3-7fcc-4e55-99d6-d892fc3904f4)


