### PR TITLE
Requests iframe height for better sizing

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,1 @@
-STORYBOOK_URL=https://63e4f71c39dc65c5c703c1e8-trawpnaxme.chromatic.com
+STORYBOOK_URL=https://main--63e4f71c39dc65c5c703c1e8.chromatic.com/

--- a/docs/lsd/components/Autocomplete.mdx
+++ b/docs/lsd/components/Autocomplete.mdx
@@ -6,4 +6,4 @@ import { StorybookDemo } from '@site/src/components/mdx/StorybookDemo';
 
 # Autocomplete
 
-<StorybookDemo name="Autocomplete" storybookUrl="https://63e4f71c39dc65c5c703c1e8-trawpnaxme.chromatic.com" docId="autocomplete--docs" globalTypes={{}} componentProperties={[]} />
+<StorybookDemo name="Autocomplete" storybookUrl="https://main--63e4f71c39dc65c5c703c1e8.chromatic.com/" docId="autocomplete--docs" globalTypes={{}} componentProperties={[]} />

--- a/docs/lsd/components/Badge.mdx
+++ b/docs/lsd/components/Badge.mdx
@@ -6,4 +6,4 @@ import { StorybookDemo } from '@site/src/components/mdx/StorybookDemo';
 
 # Badge
 
-<StorybookDemo name="Badge" storybookUrl="https://63e4f71c39dc65c5c703c1e8-trawpnaxme.chromatic.com" docId="badge--docs" globalTypes={{}} componentProperties={[]} />
+<StorybookDemo name="Badge" storybookUrl="https://main--63e4f71c39dc65c5c703c1e8.chromatic.com/" docId="badge--docs" globalTypes={{}} componentProperties={[]} />

--- a/docs/lsd/components/Breadcrumb.mdx
+++ b/docs/lsd/components/Breadcrumb.mdx
@@ -6,4 +6,4 @@ import { StorybookDemo } from '@site/src/components/mdx/StorybookDemo';
 
 # Breadcrumb
 
-<StorybookDemo name="Breadcrumb" storybookUrl="https://63e4f71c39dc65c5c703c1e8-trawpnaxme.chromatic.com" docId="breadcrumb--docs" globalTypes={{}} componentProperties={[]} />
+<StorybookDemo name="Breadcrumb" storybookUrl="https://main--63e4f71c39dc65c5c703c1e8.chromatic.com/" docId="breadcrumb--docs" globalTypes={{}} componentProperties={[]} />

--- a/docs/lsd/components/Button.mdx
+++ b/docs/lsd/components/Button.mdx
@@ -6,4 +6,4 @@ import { StorybookDemo } from '@site/src/components/mdx/StorybookDemo';
 
 # Button
 
-<StorybookDemo name="Button" storybookUrl="https://63e4f71c39dc65c5c703c1e8-trawpnaxme.chromatic.com" docId="button--docs" globalTypes={{}} componentProperties={[]} />
+<StorybookDemo name="Button" storybookUrl="https://main--63e4f71c39dc65c5c703c1e8.chromatic.com/" docId="button--docs" globalTypes={{}} componentProperties={[]} />

--- a/docs/lsd/components/ButtonGroup.mdx
+++ b/docs/lsd/components/ButtonGroup.mdx
@@ -6,4 +6,4 @@ import { StorybookDemo } from '@site/src/components/mdx/StorybookDemo';
 
 # ButtonGroup
 
-<StorybookDemo name="ButtonGroup" storybookUrl="https://63e4f71c39dc65c5c703c1e8-trawpnaxme.chromatic.com" docId="buttongroup--docs" globalTypes={{}} componentProperties={[]} />
+<StorybookDemo name="ButtonGroup" storybookUrl="https://main--63e4f71c39dc65c5c703c1e8.chromatic.com/" docId="buttongroup--docs" globalTypes={{}} componentProperties={[]} />

--- a/docs/lsd/components/Card.mdx
+++ b/docs/lsd/components/Card.mdx
@@ -6,4 +6,4 @@ import { StorybookDemo } from '@site/src/components/mdx/StorybookDemo';
 
 # Card
 
-<StorybookDemo name="Card" storybookUrl="https://63e4f71c39dc65c5c703c1e8-trawpnaxme.chromatic.com" docId="card--docs" globalTypes={{}} componentProperties={[]} />
+<StorybookDemo name="Card" storybookUrl="https://main--63e4f71c39dc65c5c703c1e8.chromatic.com/" docId="card--docs" globalTypes={{}} componentProperties={[]} />

--- a/docs/lsd/components/Checkbox.mdx
+++ b/docs/lsd/components/Checkbox.mdx
@@ -6,4 +6,4 @@ import { StorybookDemo } from '@site/src/components/mdx/StorybookDemo';
 
 # Checkbox
 
-<StorybookDemo name="Checkbox" storybookUrl="https://63e4f71c39dc65c5c703c1e8-trawpnaxme.chromatic.com" docId="checkbox--docs" globalTypes={{}} componentProperties={[]} />
+<StorybookDemo name="Checkbox" storybookUrl="https://main--63e4f71c39dc65c5c703c1e8.chromatic.com/" docId="checkbox--docs" globalTypes={{}} componentProperties={[]} />

--- a/docs/lsd/components/CheckboxGroup.mdx
+++ b/docs/lsd/components/CheckboxGroup.mdx
@@ -6,4 +6,4 @@ import { StorybookDemo } from '@site/src/components/mdx/StorybookDemo';
 
 # CheckboxGroup
 
-<StorybookDemo name="CheckboxGroup" storybookUrl="https://63e4f71c39dc65c5c703c1e8-trawpnaxme.chromatic.com" docId="checkboxgroup--docs" globalTypes={{}} componentProperties={[]} />
+<StorybookDemo name="CheckboxGroup" storybookUrl="https://main--63e4f71c39dc65c5c703c1e8.chromatic.com/" docId="checkboxgroup--docs" globalTypes={{}} componentProperties={[]} />

--- a/docs/lsd/components/Collapse.mdx
+++ b/docs/lsd/components/Collapse.mdx
@@ -6,4 +6,4 @@ import { StorybookDemo } from '@site/src/components/mdx/StorybookDemo';
 
 # Collapse
 
-<StorybookDemo name="Collapse" storybookUrl="https://63e4f71c39dc65c5c703c1e8-trawpnaxme.chromatic.com" docId="collapse--docs" globalTypes={{}} componentProperties={[]} />
+<StorybookDemo name="Collapse" storybookUrl="https://main--63e4f71c39dc65c5c703c1e8.chromatic.com/" docId="collapse--docs" globalTypes={{}} componentProperties={[]} />

--- a/docs/lsd/components/DateField.mdx
+++ b/docs/lsd/components/DateField.mdx
@@ -6,4 +6,4 @@ import { StorybookDemo } from '@site/src/components/mdx/StorybookDemo';
 
 # DateField
 
-<StorybookDemo name="DateField" storybookUrl="https://63e4f71c39dc65c5c703c1e8-trawpnaxme.chromatic.com" docId="datefield--uncontrolled" globalTypes={{}} componentProperties={[]} />
+<StorybookDemo name="DateField" storybookUrl="https://main--63e4f71c39dc65c5c703c1e8.chromatic.com/" docId="datefield--uncontrolled" globalTypes={{}} componentProperties={[]} />

--- a/docs/lsd/components/DatePicker.mdx
+++ b/docs/lsd/components/DatePicker.mdx
@@ -6,4 +6,4 @@ import { StorybookDemo } from '@site/src/components/mdx/StorybookDemo';
 
 # DatePicker
 
-<StorybookDemo name="DatePicker" storybookUrl="https://63e4f71c39dc65c5c703c1e8-trawpnaxme.chromatic.com" docId="datepicker--uncontrolled" globalTypes={{}} componentProperties={[]} />
+<StorybookDemo name="DatePicker" storybookUrl="https://main--63e4f71c39dc65c5c703c1e8.chromatic.com/" docId="datepicker--uncontrolled" globalTypes={{}} componentProperties={[]} />

--- a/docs/lsd/components/DateRangePicker.mdx
+++ b/docs/lsd/components/DateRangePicker.mdx
@@ -6,4 +6,4 @@ import { StorybookDemo } from '@site/src/components/mdx/StorybookDemo';
 
 # DateRangePicker
 
-<StorybookDemo name="DateRangePicker" storybookUrl="https://63e4f71c39dc65c5c703c1e8-trawpnaxme.chromatic.com" docId="daterangepicker--uncontrolled" globalTypes={{}} componentProperties={[]} />
+<StorybookDemo name="DateRangePicker" storybookUrl="https://main--63e4f71c39dc65c5c703c1e8.chromatic.com/" docId="daterangepicker--uncontrolled" globalTypes={{}} componentProperties={[]} />

--- a/docs/lsd/components/Dropdown.mdx
+++ b/docs/lsd/components/Dropdown.mdx
@@ -6,4 +6,4 @@ import { StorybookDemo } from '@site/src/components/mdx/StorybookDemo';
 
 # Dropdown
 
-<StorybookDemo name="Dropdown" storybookUrl="https://63e4f71c39dc65c5c703c1e8-trawpnaxme.chromatic.com" docId="dropdown--docs" globalTypes={{}} componentProperties={[]} />
+<StorybookDemo name="Dropdown" storybookUrl="https://main--63e4f71c39dc65c5c703c1e8.chromatic.com/" docId="dropdown--docs" globalTypes={{}} componentProperties={[]} />

--- a/docs/lsd/components/IconButton.mdx
+++ b/docs/lsd/components/IconButton.mdx
@@ -6,4 +6,4 @@ import { StorybookDemo } from '@site/src/components/mdx/StorybookDemo';
 
 # IconButton
 
-<StorybookDemo name="IconButton" storybookUrl="https://63e4f71c39dc65c5c703c1e8-trawpnaxme.chromatic.com" docId="iconbutton--docs" globalTypes={{}} componentProperties={[]} />
+<StorybookDemo name="IconButton" storybookUrl="https://main--63e4f71c39dc65c5c703c1e8.chromatic.com/" docId="iconbutton--docs" globalTypes={{}} componentProperties={[]} />

--- a/docs/lsd/components/IconButtonGroup.mdx
+++ b/docs/lsd/components/IconButtonGroup.mdx
@@ -6,4 +6,4 @@ import { StorybookDemo } from '@site/src/components/mdx/StorybookDemo';
 
 # IconButtonGroup
 
-<StorybookDemo name="IconButtonGroup" storybookUrl="https://63e4f71c39dc65c5c703c1e8-trawpnaxme.chromatic.com" docId="iconbuttongroup--docs" globalTypes={{}} componentProperties={[]} />
+<StorybookDemo name="IconButtonGroup" storybookUrl="https://main--63e4f71c39dc65c5c703c1e8.chromatic.com/" docId="iconbuttongroup--docs" globalTypes={{}} componentProperties={[]} />

--- a/docs/lsd/components/Modal.mdx
+++ b/docs/lsd/components/Modal.mdx
@@ -6,4 +6,4 @@ import { StorybookDemo } from '@site/src/components/mdx/StorybookDemo';
 
 # Modal
 
-<StorybookDemo name="Modal" storybookUrl="https://63e4f71c39dc65c5c703c1e8-trawpnaxme.chromatic.com" docId="modal--docs" globalTypes={{}} componentProperties={[]} />
+<StorybookDemo name="Modal" storybookUrl="https://main--63e4f71c39dc65c5c703c1e8.chromatic.com/" docId="modal--docs" globalTypes={{}} componentProperties={[]} />

--- a/docs/lsd/components/NumberInput.mdx
+++ b/docs/lsd/components/NumberInput.mdx
@@ -6,4 +6,4 @@ import { StorybookDemo } from '@site/src/components/mdx/StorybookDemo';
 
 # NumberInput
 
-<StorybookDemo name="NumberInput" storybookUrl="https://63e4f71c39dc65c5c703c1e8-trawpnaxme.chromatic.com" docId="numberinput--docs" globalTypes={{}} componentProperties={[]} />
+<StorybookDemo name="NumberInput" storybookUrl="https://main--63e4f71c39dc65c5c703c1e8.chromatic.com/" docId="numberinput--docs" globalTypes={{}} componentProperties={[]} />

--- a/docs/lsd/components/Quote.mdx
+++ b/docs/lsd/components/Quote.mdx
@@ -6,4 +6,4 @@ import { StorybookDemo } from '@site/src/components/mdx/StorybookDemo';
 
 # Quote
 
-<StorybookDemo name="Quote" storybookUrl="https://63e4f71c39dc65c5c703c1e8-trawpnaxme.chromatic.com" docId="quote--docs" globalTypes={{}} componentProperties={[]} />
+<StorybookDemo name="Quote" storybookUrl="https://main--63e4f71c39dc65c5c703c1e8.chromatic.com/" docId="quote--docs" globalTypes={{}} componentProperties={[]} />

--- a/docs/lsd/components/RadioButton.mdx
+++ b/docs/lsd/components/RadioButton.mdx
@@ -6,4 +6,4 @@ import { StorybookDemo } from '@site/src/components/mdx/StorybookDemo';
 
 # RadioButton
 
-<StorybookDemo name="RadioButton" storybookUrl="https://63e4f71c39dc65c5c703c1e8-trawpnaxme.chromatic.com" docId="radiobutton--docs" globalTypes={{}} componentProperties={[]} />
+<StorybookDemo name="RadioButton" storybookUrl="https://main--63e4f71c39dc65c5c703c1e8.chromatic.com/" docId="radiobutton--docs" globalTypes={{}} componentProperties={[]} />

--- a/docs/lsd/components/RadioButtonGroup.mdx
+++ b/docs/lsd/components/RadioButtonGroup.mdx
@@ -6,4 +6,4 @@ import { StorybookDemo } from '@site/src/components/mdx/StorybookDemo';
 
 # RadioButtonGroup
 
-<StorybookDemo name="RadioButtonGroup" storybookUrl="https://63e4f71c39dc65c5c703c1e8-trawpnaxme.chromatic.com" docId="radiobuttongroup--docs" globalTypes={{}} componentProperties={[]} />
+<StorybookDemo name="RadioButtonGroup" storybookUrl="https://main--63e4f71c39dc65c5c703c1e8.chromatic.com/" docId="radiobuttongroup--docs" globalTypes={{}} componentProperties={[]} />

--- a/docs/lsd/components/Table.mdx
+++ b/docs/lsd/components/Table.mdx
@@ -6,4 +6,4 @@ import { StorybookDemo } from '@site/src/components/mdx/StorybookDemo';
 
 # Table
 
-<StorybookDemo name="Table" storybookUrl="https://63e4f71c39dc65c5c703c1e8-trawpnaxme.chromatic.com" docId="table--docs" globalTypes={{}} componentProperties={[]} />
+<StorybookDemo name="Table" storybookUrl="https://main--63e4f71c39dc65c5c703c1e8.chromatic.com/" docId="table--docs" globalTypes={{}} componentProperties={[]} />

--- a/docs/lsd/components/Tabs.mdx
+++ b/docs/lsd/components/Tabs.mdx
@@ -6,4 +6,4 @@ import { StorybookDemo } from '@site/src/components/mdx/StorybookDemo';
 
 # Tabs
 
-<StorybookDemo name="Tabs" storybookUrl="https://63e4f71c39dc65c5c703c1e8-trawpnaxme.chromatic.com" docId="tabs--docs" globalTypes={{}} componentProperties={[]} />
+<StorybookDemo name="Tabs" storybookUrl="https://main--63e4f71c39dc65c5c703c1e8.chromatic.com/" docId="tabs--docs" globalTypes={{}} componentProperties={[]} />

--- a/docs/lsd/components/Tag.mdx
+++ b/docs/lsd/components/Tag.mdx
@@ -6,4 +6,4 @@ import { StorybookDemo } from '@site/src/components/mdx/StorybookDemo';
 
 # Tag
 
-<StorybookDemo name="Tag" storybookUrl="https://63e4f71c39dc65c5c703c1e8-trawpnaxme.chromatic.com" docId="tag--docs" globalTypes={{}} componentProperties={[]} />
+<StorybookDemo name="Tag" storybookUrl="https://main--63e4f71c39dc65c5c703c1e8.chromatic.com/" docId="tag--docs" globalTypes={{}} componentProperties={[]} />

--- a/docs/lsd/components/TextField.mdx
+++ b/docs/lsd/components/TextField.mdx
@@ -6,4 +6,4 @@ import { StorybookDemo } from '@site/src/components/mdx/StorybookDemo';
 
 # TextField
 
-<StorybookDemo name="TextField" storybookUrl="https://63e4f71c39dc65c5c703c1e8-trawpnaxme.chromatic.com" docId="textfield--docs" globalTypes={{}} componentProperties={[]} />
+<StorybookDemo name="TextField" storybookUrl="https://main--63e4f71c39dc65c5c703c1e8.chromatic.com/" docId="textfield--docs" globalTypes={{}} componentProperties={[]} />

--- a/docs/lsd/components/ThemeProvider.mdx
+++ b/docs/lsd/components/ThemeProvider.mdx
@@ -6,4 +6,4 @@ import { StorybookDemo } from '@site/src/components/mdx/StorybookDemo';
 
 # ThemeProvider
 
-<StorybookDemo name="ThemeProvider" storybookUrl="https://63e4f71c39dc65c5c703c1e8-trawpnaxme.chromatic.com" docId="themeprovider--docs" globalTypes={{}} componentProperties={[]} />
+<StorybookDemo name="ThemeProvider" storybookUrl="https://main--63e4f71c39dc65c5c703c1e8.chromatic.com/" docId="themeprovider--docs" globalTypes={{}} componentProperties={[]} />

--- a/docs/lsd/components/Toast.mdx
+++ b/docs/lsd/components/Toast.mdx
@@ -6,4 +6,4 @@ import { StorybookDemo } from '@site/src/components/mdx/StorybookDemo';
 
 # Toast
 
-<StorybookDemo name="Toast" storybookUrl="https://63e4f71c39dc65c5c703c1e8-trawpnaxme.chromatic.com" docId="toast--docs" globalTypes={{}} componentProperties={[]} />
+<StorybookDemo name="Toast" storybookUrl="https://main--63e4f71c39dc65c5c703c1e8.chromatic.com/" docId="toast--docs" globalTypes={{}} componentProperties={[]} />

--- a/docs/lsd/components/ToastProvider.mdx
+++ b/docs/lsd/components/ToastProvider.mdx
@@ -6,4 +6,4 @@ import { StorybookDemo } from '@site/src/components/mdx/StorybookDemo';
 
 # ToastProvider
 
-<StorybookDemo name="ToastProvider" storybookUrl="https://63e4f71c39dc65c5c703c1e8-trawpnaxme.chromatic.com" docId="toastprovider--docs" globalTypes={{}} componentProperties={[]} />
+<StorybookDemo name="ToastProvider" storybookUrl="https://main--63e4f71c39dc65c5c703c1e8.chromatic.com/" docId="toastprovider--docs" globalTypes={{}} componentProperties={[]} />

--- a/docs/lsd/components/Typography.mdx
+++ b/docs/lsd/components/Typography.mdx
@@ -6,4 +6,4 @@ import { StorybookDemo } from '@site/src/components/mdx/StorybookDemo';
 
 # Typography
 
-<StorybookDemo name="Typography" storybookUrl="https://63e4f71c39dc65c5c703c1e8-trawpnaxme.chromatic.com" docId="typography--docs" globalTypes={{}} componentProperties={[]} />
+<StorybookDemo name="Typography" storybookUrl="https://main--63e4f71c39dc65c5c703c1e8.chromatic.com/" docId="typography--docs" globalTypes={{}} componentProperties={[]} />

--- a/docs/lsd/design-tokens/Colors.mdx
+++ b/docs/lsd/design-tokens/Colors.mdx
@@ -6,4 +6,4 @@ import { StorybookDemo } from '@site/src/components/mdx/StorybookDemo';
 
 # Colors
 
-<StorybookDemo name="Colors" docId="themeprovider--docs" storybookUrl="https://63e4f71c39dc65c5c703c1e8-trawpnaxme.chromatic.com" storyId="themeprovider--colors" globalTypes={{}} componentProperties={[]} />
+<StorybookDemo name="Colors" docId="themeprovider--docs" storybookUrl="https://main--63e4f71c39dc65c5c703c1e8.chromatic.com/" storyId="themeprovider--colors" globalTypes={{}} componentProperties={[]} />

--- a/docs/lsd/design-tokens/Spacing.mdx
+++ b/docs/lsd/design-tokens/Spacing.mdx
@@ -6,4 +6,4 @@ import { StorybookDemo } from '@site/src/components/mdx/StorybookDemo';
 
 # Spacing
 
-<StorybookDemo name="Spacing" docId="themeprovider--docs" storybookUrl="https://63e4f71c39dc65c5c703c1e8-trawpnaxme.chromatic.com" storyId="themeprovider--spacing" globalTypes={{}} componentProperties={[]} />
+<StorybookDemo name="Spacing" docId="themeprovider--docs" storybookUrl="https://main--63e4f71c39dc65c5c703c1e8.chromatic.com/" storyId="themeprovider--spacing" globalTypes={{}} componentProperties={[]} />

--- a/docs/lsd/design-tokens/Typography.mdx
+++ b/docs/lsd/design-tokens/Typography.mdx
@@ -6,4 +6,4 @@ import { StorybookDemo } from '@site/src/components/mdx/StorybookDemo';
 
 # Typography
 
-<StorybookDemo name="Typography" docId="themeprovider--docs" storybookUrl="https://63e4f71c39dc65c5c703c1e8-trawpnaxme.chromatic.com" storyId="themeprovider--typography" globalTypes={{}} componentProperties={[]} />
+<StorybookDemo name="Typography" docId="themeprovider--docs" storybookUrl="https://main--63e4f71c39dc65c5c703c1e8.chromatic.com/" storyId="themeprovider--typography" globalTypes={{}} componentProperties={[]} />

--- a/src/components/mdx/ImageGrid/ImageGrid.tsx
+++ b/src/components/mdx/ImageGrid/ImageGrid.tsx
@@ -95,8 +95,6 @@ export const ImageGrid: React.FC<ImageGridProps> = ({
     }
   }, [])
 
-  console.log('Hello!', folder + thumbnailsFolder)
-
   return (
     <>
       <Grid

--- a/src/components/mdx/StorybookDemo/StoryBookDemo.module.scss
+++ b/src/components/mdx/StorybookDemo/StoryBookDemo.module.scss
@@ -8,7 +8,6 @@
   iframe {
     transform: translateY(-20px);
     width: 100%;
-    height: 6000px;
     background-color: transparent;
   }
 }


### PR DESCRIPTION
In this PR, we request the storybook iframe's height, and use that height instead of hard coding 6000px for every single iframe. 

I've also updated the storybookUrl to the permalink: https://main--63e4f71c39dc65c5c703c1e8.chromatic.com/ - @jeangovil happy to remove this if you don't think it makes sense.

# How to test this

Go to this PR's chromatic link ([current one at the time of me writing this is this](https://logos-brand-guidelines-git-request-iframe-height-acidinfo.vercel.app/)) and go to a lsd component page. There shouldn't be large empty spaces at the bottom.